### PR TITLE
Task/IOS-646 Change WireGuard keys timestamps format

### DIFF
--- a/IVPNClient/Scenes/ViewControllers/WireGuardSettingsViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/WireGuardSettingsViewController.swift
@@ -62,8 +62,8 @@ class WireGuardSettingsViewController: UITableViewController {
     private func setupView() {
         ipAddressLabel.text = KeyChain.wgIpAddress
         publicKeyLabel.text = KeyChain.wgPublicKey
-        keyTimestampLabel.text = AppKeyManager.keyTimestamp.formatDateTime()
-        keyExpirationTimestampLabel.text = AppKeyManager.keyExpirationTimestamp.formatDateTime()
+        keyTimestampLabel.text = AppKeyManager.keyTimestamp.formatDate()
+        keyExpirationTimestampLabel.text = AppKeyManager.keyExpirationTimestamp.formatDate()
         keyRegenerationTimestampLabel.text = AppKeyManager.keyRegenerationTimestamp.formatDate()
     }
     

--- a/IVPNClient/Utilities/Extensions/Date+Ext.swift
+++ b/IVPNClient/Utilities/Extensions/Date+Ext.swift
@@ -12,8 +12,8 @@ extension Date {
     
     private static let logFormat = "dd.MM.yyyy HH:mm:ss"
     private static let fileNameFormat = "MMddyyyyHHmmss"
-    private static let dateFormat = "dd.MM.yyyy"
-    private static let dateTimeFormat = "dd.MM.yyyy HH:mm"
+    private static let dateFormat = "d MMM yyyy"
+    private static let dateTimeFormat = "d MMM yyyy HH:mm"
     
     static func logTime() -> String {
         return formatted(format: logFormat)


### PR DESCRIPTION
## Pull Request Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation content changes

## Description

Update timestamp format for all WireGuard keys dates with next format:`5 Jun 2020`.
Swift formatter should be updated to `d MMM yyyy`.

## QA Notes

WireGuard settings screen should be reviewed for the new date formats.