### PR TITLE
Task/IOS-691 Change date format to YYYY-MMM-DD

### DIFF
--- a/IVPNClient.xcodeproj/project.pbxproj
+++ b/IVPNClient.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		82A9E8C623471EBE007BCA7E /* staging.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 82A9E8C423471EBE007BCA7E /* staging.xcconfig */; };
 		82A9E8C923471FB2007BCA7E /* wg-release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 82A9E8C723471FB2007BCA7E /* wg-release.xcconfig */; };
 		82A9E8CA23471FB2007BCA7E /* wg-staging.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 82A9E8C823471FB2007BCA7E /* wg-staging.xcconfig */; };
+		82AA85782514DEB40027DAB8 /* Date+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D90470216C7DAF0032F3BE /* Date+Ext.swift */; };
 		82AA8818231E330A00E18ECB /* SessionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AA8817231E330A00E18ECB /* SessionStatus.swift */; };
 		82AAF0E92253A4A8005E792F /* StaticWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AAF0E82253A4A8005E792F /* StaticWebViewController.swift */; };
 		82B51CDF21DE3E31005CC9C9 /* UITableView+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B51CDE21DE3E31005CC9C9 /* UITableView+Ext.swift */; };
@@ -1986,6 +1987,7 @@
 				826F7F1623A7A05F00777DB9 /* TodayViewController.swift in Sources */,
 				826F7F4023A7AA8200777DB9 /* Capability.swift in Sources */,
 				826F7F3B23A7AA3D00777DB9 /* OpenVPNProtocol.swift in Sources */,
+				82AA85782514DEB40027DAB8 /* Date+Ext.swift in Sources */,
 				826F7F3123A7A8CE00777DB9 /* Result.swift in Sources */,
 				826F7F3C23A7AA4200777DB9 /* WireGuardProtocol.swift in Sources */,
 				826F7F3F23A7AA6A00777DB9 /* ErrorResult.swift in Sources */,

--- a/IVPNClient/Enums/ServiceDuration.swift
+++ b/IVPNClient/Enums/ServiceDuration.swift
@@ -51,11 +51,7 @@ enum ServiceDuration: CaseIterable {
     }
     
     func willBeActiveUntilFrom(date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-        
-        return formatter.string(from: activeUntilFrom(date: date))
+        return activeUntilFrom(date: date).formatDate()
     }
     
 }

--- a/IVPNClient/Models/ServiceStatus.swift
+++ b/IVPNClient/Models/ServiceStatus.swift
@@ -79,7 +79,7 @@ struct ServiceStatus: Codable {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .none
-        formatter.dateFormat = "dd.MM.yyyy"
+        formatter.dateFormat = "yyyy-MMM-dd"
         
         return formatter.string(from: Date(timeIntervalSince1970: TimeInterval(activeUntil ?? 0)))
     }

--- a/IVPNClient/Models/ServiceStatus.swift
+++ b/IVPNClient/Models/ServiceStatus.swift
@@ -76,12 +76,7 @@ struct ServiceStatus: Codable {
     }
     
     func activeUntilString() -> String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-        formatter.dateFormat = "yyyy-MMM-dd"
-        
-        return formatter.string(from: Date(timeIntervalSince1970: TimeInterval(activeUntil ?? 0)))
+        return Date(timeIntervalSince1970: TimeInterval(activeUntil ?? 0)).formatDate()
     }
     
     func isEnabled(capability: Capability) -> Bool {

--- a/IVPNClient/Scenes/MainScreen/Map/MapMarkerView.swift
+++ b/IVPNClient/Scenes/MainScreen/Map/MapMarkerView.swift
@@ -95,7 +95,6 @@ class MapMarkerView: UIView {
         self.markerType = type
     }
 
-    
     override func updateConstraints() {
         setupConstraints()
         initCircles()

--- a/IVPNClient/Scenes/TableCells/ServerTableViewCell.swift
+++ b/IVPNClient/Scenes/TableCells/ServerTableViewCell.swift
@@ -40,7 +40,7 @@ class ServerTableViewCell: UITableViewCell {
                 serverName.text = "Fastest server"
                 configureButton.isHidden = false
                 configureButton.isUserInteractionEnabled = true
-            } else if (isMultiHop && indexPath.row == 0 || !isMultiHop && indexPath.row == 1) {
+            } else if isMultiHop && indexPath.row == 0 || !isMultiHop && indexPath.row == 1 {
                 flagImage.image = UIImage(named: "icon-shuffle")
                 serverName.text = "Random server"
                 configureButton.isHidden = true

--- a/IVPNClient/Utilities/Extensions/Date+Ext.swift
+++ b/IVPNClient/Utilities/Extensions/Date+Ext.swift
@@ -25,10 +25,10 @@ import Foundation
 
 extension Date {
     
-    private static let logFormat = "dd.MM.yyyy HH:mm:ss"
-    private static let fileNameFormat = "MMddyyyyHHmmss"
-    private static let dateFormat = "d MMM yyyy"
-    private static let dateTimeFormat = "d MMM yyyy HH:mm"
+    private static let logFormat = "yyyy-MMM-dd HH:mm:ss"
+    private static let fileNameFormat = "yyyy-MMM-dd-HHmmss"
+    private static let dateFormat = "yyyy-MMM-dd"
+    private static let dateTimeFormat = "yyyy-MMM-dd HH:mm"
     
     static func logTime() -> String {
         return formatted(format: logFormat)

--- a/IVPNClient/Utilities/Extensions/NETunnelProviderProtocol+Ext.swift
+++ b/IVPNClient/Utilities/Extensions/NETunnelProviderProtocol+Ext.swift
@@ -55,7 +55,7 @@ extension NETunnelProviderProtocol {
         
         var builder = OpenVPNTunnelProvider.ConfigurationBuilder(sessionConfiguration: sessionBuilder.build())
         builder.shouldDebug = true
-        builder.debugLogFormat = "$Ddd.MM.yyyy HH:mm:ss$d $L $M"
+        builder.debugLogFormat = "$Dyyyy-MMM-dd HH:mm:ss$d $L $M"
         builder.masksPrivateData = false
         
         let openVPNconfiguration = builder.build()

--- a/UnitTests/Models/ServiceStatusTests.swift
+++ b/UnitTests/Models/ServiceStatusTests.swift
@@ -41,7 +41,7 @@ class ServiceStatusTests: XCTestCase {
     }
     
     func test_activeUntilString() {
-        XCTAssertEqual(model.activeUntilString(), "10.01.2020")
+        XCTAssertEqual(model.activeUntilString(), "2020-Jan-10")
     }
     
     func test_isEnabled() {


### PR DESCRIPTION
## Pull Request Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation content changes

## Description

We need to change format for all dates displayed in the apps to `YYYY-MMM-DD` (like 2020-Aug-11).

## QA Notes

**Dates are displayed in:**

- Subscription expiration on the account screen
- Subscription extend date on "Buy" button
- Subscription activation message
- WireGuard key dates
- Logs date and time