### PR TITLE
Bugfix/IOS-705 Loading connection info failed message disappears after closing Account screen

### DIFF
--- a/IVPNClient/Models/ServiceStatus.swift
+++ b/IVPNClient/Models/ServiceStatus.swift
@@ -47,7 +47,7 @@ struct ServiceStatus: Codable {
     
     init() {
         let service = ServiceStatus.load()
-        isActive = service?.isActive ?? false
+        isActive = service?.isActive ?? true
         currentPlan = service?.currentPlan ?? nil
         activeUntil = service?.activeUntil ?? nil
         isOnFreeTrial = service?.isOnFreeTrial ?? false

--- a/IVPNClient/Scenes/MainScreen/MainViewController+Ext.swift
+++ b/IVPNClient/Scenes/MainScreen/MainViewController+Ext.swift
@@ -57,9 +57,6 @@ extension MainViewController: UIAdaptivePresentationControllerDelegate {
             NotificationCenter.default.removeObserver(controlPanelViewController, name: Notification.Name.ServiceAuthorized, object: nil)
             NotificationCenter.default.removeObserver(controlPanelViewController, name: Notification.Name.SubscriptionActivated, object: nil)
         }
-        
-        mainView.infoAlertViewModel.infoAlert = .subscriptionExpiration
-        mainView.updateInfoAlert()
     }
     
 }

--- a/IVPNClient/Scenes/MainScreen/MainViewController.swift
+++ b/IVPNClient/Scenes/MainScreen/MainViewController.swift
@@ -136,8 +136,6 @@ class MainViewController: UIViewController {
         
         let request = ApiRequestDI(method: .get, endpoint: Config.apiGeoLookup)
         
-        mainView.infoAlertViewModel.infoAlert = .subscriptionExpiration
-        mainView.updateInfoAlert()
         controlPanelViewController.controlPanelView.connectionInfoDisplayMode = .loading
         
         ApiService.shared.request(request) { [weak self] (result: Result<GeoLookup>) in
@@ -148,6 +146,8 @@ class MainViewController: UIViewController {
                 let viewModel = ProofsViewModel(model: model)
                 controlPanelViewController.connectionViewModel = viewModel
                 self.mainView.connectionViewModel = viewModel
+                self.mainView.infoAlertViewModel.infoAlert = .subscriptionExpiration
+                self.mainView.updateInfoAlert()
                 
                 if !model.isIvpnServer {
                     Application.shared.geoLookup = model

--- a/IVPNClient/Scenes/MainScreen/View/MainView.swift
+++ b/IVPNClient/Scenes/MainScreen/View/MainView.swift
@@ -85,7 +85,6 @@ class MainView: UIView {
     
     func updateInfoAlert() {
         if infoAlertViewModel.shouldDisplay {
-            infoAlertViewModel.update()
             infoAlertView.show(type: infoAlertViewModel.type, text: infoAlertViewModel.text, actionText: infoAlertViewModel.actionText)
         } else {
             infoAlertView.hide()

--- a/IVPNClient/ViewModels/InfoAlertViewModel.swift
+++ b/IVPNClient/ViewModels/InfoAlertViewModel.swift
@@ -73,16 +73,6 @@ class InfoAlertViewModel {
     
     var infoAlert: InfoAlert = .subscriptionExpiration
     
-    // MARK: - Methods -
-    
-    func update() {
-        guard infoAlert != .connectionInfoFailure else { return }
-        
-        if shouldDisplay {
-            infoAlert = .subscriptionExpiration
-        }
-    }
-    
 }
 
 // MARK: - InfoAlertViewModel extension -

--- a/IVPNClient/ViewModels/InfoAlertViewModel.swift
+++ b/IVPNClient/ViewModels/InfoAlertViewModel.swift
@@ -91,6 +91,10 @@ extension InfoAlertViewModel {
 extension InfoAlertViewModel: InfoAlertViewDelegate {
     
     func action() {
+        guard shouldDisplay else {
+            return
+        }
+        
         switch infoAlert {
         case .subscriptionExpiration:
             if let topViewController = UIApplication.topViewController() as? MainViewController {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation content changes

## Description

When geolocation API fetch fails, app presents "Loading connection info failed" message on the main screen. But if Account screen is opened/closed that message disappears from the main screen.

## QA Notes

**Expected result:**
The fail message should remain on the main screen until geolocation API fetch is successful.