### PR TITLE
Bugfix/IOS-704 Ping service crash

### DIFF
--- a/IVPNClient/Scenes/MainScreen/MainViewController.swift
+++ b/IVPNClient/Scenes/MainScreen/MainViewController.swift
@@ -192,7 +192,9 @@ class MainViewController: UIViewController {
             case .success(let serverList):
                 Application.shared.serverList = serverList
                 Pinger.shared.serverList = Application.shared.serverList
-                Pinger.shared.ping()
+                DispatchQueue.async {
+                    Pinger.shared.ping()
+                }
             default:
                 break
             }

--- a/IVPNClient/Utilities/Pinger/Pinger.swift
+++ b/IVPNClient/Utilities/Pinger/Pinger.swift
@@ -43,6 +43,10 @@ class Pinger {
     func ping() {
         guard evaluatePing() else { return }
         
+        PingMannager.shared.stopPing()
+        PingMannager.shared.pings = []
+        UserDefaults.shared.set(Date().timeIntervalSince1970, forKey: "LastPingTimestamp")
+        
         for server in serverList.servers {
             if let ipAddress = server.ipAddresses.first {
                 guard !ipAddress.isEmpty else { continue }
@@ -126,7 +130,6 @@ extension Pinger: PingDelegate {
             if pingsCount > 0 {
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: Notification.Name.PingDidComplete, object: nil)
-                    UserDefaults.shared.set(Date().timeIntervalSince1970, forKey: "LastPingTimestamp")
                     log(info: "Pinger service finished")
                 }
             }


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation content changes

## Description

Ping service can cause app to crash when started simultaneously in multiple threads.