### PR TITLE
Task/IOS-693 Update map position when selecting a server in the list of servers

### DIFF
--- a/IVPNClient/Scenes/MainScreen/Map/MapScrollView.swift
+++ b/IVPNClient/Scenes/MainScreen/Map/MapScrollView.swift
@@ -249,12 +249,7 @@ class MapScrollView: UIScrollView {
                 make.top.equalTo(point.1 + 17)
             }
             
-            let nearByServers = getNearByServers(server: server)
-            connectToServerPopup.servers = nearByServers
-            connectToServerPopup.vpnServer = nearByServers.first ?? server
-            connectToServerPopup.show()
-            NotificationCenter.default.post(name: Notification.Name.HideConnectionInfoPopup, object: nil)
-            
+            showConnectToServerPopup(server: server)
             updateMapPosition(latitude: server.latitude, longitude: server.longitude, animated: true, isLocalPosition: false, updateMarkers: false)
             
             if Application.shared.connectionManager.status.isDisconnected() && Application.shared.serverList.validateServer(firstServer: Application.shared.settings.selectedServer, secondServer: server) {
@@ -271,6 +266,25 @@ class MapScrollView: UIScrollView {
                 NotificationCenter.default.post(name: Notification.Name.ServerSelected, object: nil)
             }
         }
+    }
+    
+    @objc private func updateMapPositionToSelectedServer() {
+        guard Application.shared.connectionManager.status.isDisconnected() else {
+            return
+        }
+        
+        let server = UserDefaults.shared.isMultiHop ? Application.shared.settings.selectedExitServer : Application.shared.settings.selectedServer
+        
+        updateMapPosition(latitude: server.latitude, longitude: server.longitude, animated: true, isLocalPosition: false, updateMarkers: false)
+        showConnectToServerPopup(server: server)
+    }
+    
+    private func showConnectToServerPopup(server: VPNServer) {
+        let nearByServers = getNearByServers(server: server)
+        connectToServerPopup.servers = nearByServers
+        connectToServerPopup.vpnServer = nearByServers.first ?? server
+        connectToServerPopup.show()
+        NotificationCenter.default.post(name: Notification.Name.HideConnectionInfoPopup, object: nil)
     }
     
     private func getNearByServers(server selectedServer: VPNServer) -> [VPNServer] {

--- a/IVPNClient/Scenes/ViewControllers/ServerViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/ServerViewController.swift
@@ -239,6 +239,7 @@ extension ServerViewController {
         }
         
         NotificationCenter.default.post(name: Notification.Name.ServerSelected, object: nil)
+        NotificationCenter.default.post(name: Notification.Name.ShowConnectToServerPopup, object: nil)
         
         if serverDifferentToSelectedServer {
             if Application.shared.settings.selectedServer.fastest {

--- a/IVPNClient/Utilities/Extensions/NotificationName+Ext.swift
+++ b/IVPNClient/Utilities/Extensions/NotificationName+Ext.swift
@@ -45,6 +45,7 @@ extension Notification.Name {
     public static let UpdateControlPanel = Notification.Name("updateControlPanel")
     public static let ProtocolSelected = Notification.Name("protocolSelected")
     public static let HideConnectionInfoPopup = Notification.Name("hideConnectionInfoPopup")
+    public static let ShowConnectToServerPopup = Notification.Name("showConnectToServerPopup")
     public static let HideConnectToServerPopup = Notification.Name("hideConnectToServerPopup")
     public static let CenterMap = Notification.Name("centerMap")
     


### PR DESCRIPTION
## Pull Request Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation content changes

## Description

When VPN is disconnected and user selects a different server on the servers list, the map should update position to new selected server + show the “Connect to server“ tooltip.