### PR TITLE
Bugfix/IOS-707 App connects to another random server when trying to disconnect from an untrusted network

### DIFF
--- a/IVPNClient/Scenes/MainScreen/ControlPanel/ControlPanelViewController.swift
+++ b/IVPNClient/Scenes/MainScreen/ControlPanel/ControlPanelViewController.swift
@@ -244,8 +244,11 @@ class ControlPanelViewController: UITableViewController {
         registerUserActivity(type: UserActivityType.Disconnect, title: UserActivityTitle.Disconnect)
         
         DispatchQueue.delay(0.5) {
-            Pinger.shared.ping()
-            Application.shared.settings.updateRandomServer()
+            if Application.shared.connectionManager.status.isDisconnected() {
+                Pinger.shared.ping()
+                Application.shared.settings.updateRandomServer()
+            }
+            
         }
     }
     


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation content changes

## Description

When trying to disconnect from an untrusted network while the random server is selected, the app will connect to a different server.

**Expected result:**  
The app should remain connected to the same server when trying to disconnect from an untrusted network, regardless if "random server" is selected.