### PR TITLE
Feature/IOS-708 As a user, i want an indicator for hardcore AntiTracker on the control panel

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Lint Code Base
-        uses: github/super-linter@v3.10.0
+        uses: docker://github/super-linter:v3.13.1
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_MD: false

--- a/IVPNClient/Colors.xcassets/Contents.json
+++ b/IVPNClient/Colors.xcassets/Contents.json
@@ -1,6 +1,6 @@
 {
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/IVPNClient/Colors.xcassets/ivpnDarkRed.colorset/Contents.json
+++ b/IVPNClient/Colors.xcassets/ivpnDarkRed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "42",
+          "green" : "21",
+          "red" : "119"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/IVPNClient/Config/Theme.swift
+++ b/IVPNClient/Config/Theme.swift
@@ -73,5 +73,6 @@ struct Theme {
     static let ivpnDarkYellow = "ivpnDarkYellow"
     static let ivpnLightGreen = "ivpnLightGreen"
     static let ivpnDarkGreen = "ivpnDarkGreen"
+    static let ivpnDarkRed = "ivpnDarkRed"
     
 }

--- a/IVPNClient/Scenes/MainScreen/View/ControlPanelView.swift
+++ b/IVPNClient/Scenes/MainScreen/View/ControlPanelView.swift
@@ -153,8 +153,7 @@ class ControlPanelView: UITableView {
     
     func updateAntiTracker() {
         antiTrackerSwitch.isOn = UserDefaults.shared.isAntiTracker
-        // TODO: Implement with new custom color
-        // antiTrackerSwitch.onTintColor = UserDefaults.shared.isAntiTrackerHardcore ? UIColor.init(named: Theme.ivpnRed) : UIColor.init(named: Theme.ivpnBlue)
+        antiTrackerSwitch.onTintColor = UserDefaults.shared.isAntiTrackerHardcore ? UIColor.init(named: Theme.ivpnDarkRed) : UIColor.init(named: Theme.ivpnBlue)
     }
     
     func updateProtocol() {

--- a/IVPNClient/Scenes/MainScreen/View/ControlPanelView.swift
+++ b/IVPNClient/Scenes/MainScreen/View/ControlPanelView.swift
@@ -153,7 +153,8 @@ class ControlPanelView: UITableView {
     
     func updateAntiTracker() {
         antiTrackerSwitch.isOn = UserDefaults.shared.isAntiTracker
-        antiTrackerSwitch.onTintColor = UserDefaults.shared.isAntiTrackerHardcore ? UIColor.init(named: Theme.ivpnRed) : UIColor.init(named: Theme.ivpnBlue)
+        // TODO: Implement with new custom color
+        // antiTrackerSwitch.onTintColor = UserDefaults.shared.isAntiTrackerHardcore ? UIColor.init(named: Theme.ivpnRed) : UIColor.init(named: Theme.ivpnBlue)
     }
     
     func updateProtocol() {

--- a/IVPNClient/Scenes/MainScreen/View/ControlPanelView.swift
+++ b/IVPNClient/Scenes/MainScreen/View/ControlPanelView.swift
@@ -153,10 +153,7 @@ class ControlPanelView: UITableView {
     
     func updateAntiTracker() {
         antiTrackerSwitch.isOn = UserDefaults.shared.isAntiTracker
-        
-        // TODO: Implement custom switch color when Hard Core AntiTracker is enabled
-        antiTrackerSwitch.onTintColor = UIColor.init(named: Theme.ivpnBlue)
-        // antiTrackerSwitch.onTintColor = UserDefaults.shared.isAntiTrackerHardcore ? UIColor.init(named: Theme.ivpnRedOff) : UIColor.init(named: Theme.ivpnBlue)
+        antiTrackerSwitch.onTintColor = UserDefaults.shared.isAntiTrackerHardcore ? UIColor.init(named: Theme.ivpnRed) : UIColor.init(named: Theme.ivpnBlue)
     }
     
     func updateProtocol() {


### PR DESCRIPTION
## Pull Request Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation content changes

## Description

When AntiTracker is set to hardcore mode, the AntiTracker toggle on the control panel should be in red color when enabled.