### PR TITLE
Bugfix/IOS-711 Map not centred after orientation change on iPad

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,7 @@ jobs:
         uses: github/super-linter@v3.10.0
         env:
           VALIDATE_ALL_CODEBASE: false
-          VALIDATE_MD: false
+          VALIDATE_MARKDOWN: false
           VALIDATE_GO: false
           VALIDATE_POWERSHELL: false
           DEFAULT_BRANCH: develop

--- a/IVPNClient/Scenes/MainScreen/MainViewController.swift
+++ b/IVPNClient/Scenes/MainScreen/MainViewController.swift
@@ -111,7 +111,8 @@ class MainViewController: UIViewController {
     // MARK: - Interface Orientations -
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        refreshUI()
+        floatingPanel.updateLayout()
+        mainView.updateView()
     }
     
     // MARK: - Methods -

--- a/IVPNClient/Scenes/MainScreen/MainViewController.swift
+++ b/IVPNClient/Scenes/MainScreen/MainViewController.swift
@@ -112,7 +112,7 @@ class MainViewController: UIViewController {
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         floatingPanel.updateLayout()
-        mainView.updateView()
+        mainView.updateLayout()
     }
     
     // MARK: - Methods -

--- a/IVPNClient/Scenes/MainScreen/Map/MapScrollView.swift
+++ b/IVPNClient/Scenes/MainScreen/Map/MapScrollView.swift
@@ -54,6 +54,7 @@ class MapScrollView: UIScrollView {
     let markerLocalView = MapMarkerView(type: .local)
     let markerGatewayView = MapMarkerView(type: .gateway)
     var localCoordinates: (Double, Double)?
+    var currentCoordinates: (Double, Double)?
     
     private var markers: [UIButton] = []
     private var connectToServerPopup = ConnectToServerPopupView()
@@ -108,6 +109,12 @@ class MapScrollView: UIScrollView {
         updateMapPosition(latitude: viewModel.model.latitude, longitude: viewModel.model.longitude, animated: animated, isLocalPosition: true)
     }
     
+    func updateMapPositionToCurrentCoordinates() {
+        if let currentCoordinates = currentCoordinates {
+            updateMapPosition(latitude: currentCoordinates.0, longitude: currentCoordinates.1, isLocalPosition: false, updateMarkers: false)
+        }
+    }
+    
     func updateMapPosition(latitude: Double, longitude: Double, animated: Bool = false, isLocalPosition: Bool, updateMarkers: Bool = true) {
         let halfWidth = Double(UIScreen.main.bounds.width / 2)
         let halfHeight = Double(UIScreen.main.bounds.height / 2)
@@ -126,6 +133,8 @@ class MapScrollView: UIScrollView {
         if updateMarkers {
             updateMarkerPosition(x: point.0 - 49, y: point.1 - 49, isLocalPosition: isLocalPosition)
         }
+        
+        currentCoordinates = (latitude, longitude)
     }
     
     // MARK: - Private methods -

--- a/IVPNClient/Scenes/MainScreen/View/MainView.swift
+++ b/IVPNClient/Scenes/MainScreen/View/MainView.swift
@@ -74,7 +74,7 @@ class MainView: UIView {
         updateMapPosition(animated: animated)
     }
     
-    func updateView() {
+    func updateLayout() {
         setupConstraints()
         updateInfoAlert()
         updateActionButtons()

--- a/IVPNClient/Scenes/MainScreen/View/MainView.swift
+++ b/IVPNClient/Scenes/MainScreen/View/MainView.swift
@@ -74,6 +74,13 @@ class MainView: UIView {
         updateMapPosition(animated: animated)
     }
     
+    func updateView() {
+        setupConstraints()
+        updateInfoAlert()
+        updateActionButtons()
+        mapScrollView.updateMapPositionToCurrentCoordinates()
+    }
+    
     func updateStatus(vpnStatus: NEVPNStatus) {
         updateMapPosition(vpnStatus: vpnStatus)
         mapScrollView.updateStatus(vpnStatus: vpnStatus)


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation content changes

## Description

When screen orientation is changed on an iPad device, the map is not centred correctly.