### PR TITLE
Bugfix/IOS-733 UI: Toggle is kept in disconnected state when connecting IKEv2 for the first time

### DIFF
--- a/IVPNClient/Managers/ConnectionManager.swift
+++ b/IVPNClient/Managers/ConnectionManager.swift
@@ -38,10 +38,10 @@ class ConnectionManager {
     
     var reconnectAutomatically = false
     var settings: Settings
+    var statusModificationDate = Date()
     
     var status: NEVPNStatus = .invalid {
         didSet {
-            statusModificationDate = Date()
             UserDefaults.shared.set(status.rawValue, forKey: UserDefaults.Key.connectionStatus)
         }
     }
@@ -67,7 +67,6 @@ class ConnectionManager {
     private var connected = false
     private var closeApp = false
     private var actionType: ActionType = .connect
-    private var statusModificationDate = Date()
     
     // MARK: - Initialize -
     

--- a/IVPNClient/Managers/VPNManager.swift
+++ b/IVPNClient/Managers/VPNManager.swift
@@ -129,7 +129,9 @@ class VPNManager {
         manager.loadFromPreferences { error in
             self.setupIKEv2Tunnel(manager: manager, accessDetails: accessDetails, status: status)
             manager.saveToPreferences { error in
-                completion(error)
+                manager.loadFromPreferences { error in
+                    completion(error)
+                }
             }
         }
     }

--- a/IVPNClient/Managers/VPNManager.swift
+++ b/IVPNClient/Managers/VPNManager.swift
@@ -128,13 +128,8 @@ class VPNManager {
     private func setupNEVPNManager(manager: NEVPNManager, accessDetails: AccessDetails, status: NEVPNStatus? = nil, completion: @escaping (Error?) -> Void) {
         self.setupIKEv2Tunnel(manager: manager, accessDetails: accessDetails, status: status)
         manager.saveToPreferences { error in
-            guard error == nil else {
-                completion(nil)
-                return
-            }
-            
             manager.loadFromPreferences { error in
-                manager.protocolConfiguration?.serverAddress = accessDetails.serverAddress
+                self.setupIKEv2Tunnel(manager: manager, accessDetails: accessDetails, status: status)
                 manager.saveToPreferences { error in
                     completion(nil)
                 }
@@ -159,7 +154,6 @@ class VPNManager {
             }
             
             manager.loadFromPreferences { error in
-                manager.protocolConfiguration?.serverAddress = accessDetails.serverAddress
                 manager.saveToPreferences { error in
                     completion(nil)
                 }

--- a/IVPNClient/Managers/VPNManager.swift
+++ b/IVPNClient/Managers/VPNManager.swift
@@ -256,8 +256,6 @@ class VPNManager {
     
     func connect(tunnelType: TunnelType) {
         getManagerFor(tunnelType: tunnelType) { manager in
-            manager.isEnabled = true
-            
             do {
                 try manager.connection.startVPNTunnel()
             } catch NEVPNError.configurationInvalid {

--- a/IVPNClient/Scenes/MainScreen/MainViewController.swift
+++ b/IVPNClient/Scenes/MainScreen/MainViewController.swift
@@ -127,6 +127,8 @@ class MainViewController: UIViewController {
         if let controlPanelViewController = self.floatingPanel.contentViewController as? ControlPanelViewController {
             controlPanelViewController.updateStatus(vpnStatus: vpnStatus, animated: animated)
         }
+        
+        Application.shared.connectionManager.statusModificationDate = Date()
     }
     
     @objc func updateGeoLocation() {


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

When IKEv2 VPN is connected for the first time, toggle is kept in disconnected state until VPN is connected.

## What is the new behavior?

 When VPN is connecting, the toggle should be in the enabled state (blue color, on the right side).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
