### PR TITLE
iPad - Network Protection dialogue when setting a new trust status is cutoff

### DIFF
--- a/IVPNClient/Scenes/MainScreen/ControlPanel/ControlPanelViewController+Ext.swift
+++ b/IVPNClient/Scenes/MainScreen/ControlPanel/ControlPanelViewController+Ext.swift
@@ -61,9 +61,11 @@ extension ControlPanelViewController {
         if indexPath.row == 6 && Application.shared.network.type != NetworkType.none.rawValue {
             selectNetworkTrust(network: Application.shared.network, sourceView: controlPanelView.networkView) { trust in
                 if Application.shared.connectionManager.needToReconnect(network: Application.shared.network, newTrust: trust) {
-                    self.showReconnectPrompt {
-                        self.controlPanelView.networkView.update(trust: trust)
-                        Application.shared.connectionManager.reconnect()
+                    if let cell = tableView.cellForRow(at: indexPath) {
+                        self.showReconnectPrompt(sourceView: cell as UIView) {
+                            self.controlPanelView.networkView.update(trust: trust)
+                            Application.shared.connectionManager.reconnect()
+                        }
                     }
                 } else {
                     self.controlPanelView.networkView.update(trust: trust)

--- a/IVPNClient/Scenes/ViewControllers/NetworkProtectionViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/NetworkProtectionViewController.swift
@@ -181,9 +181,11 @@ extension NetworkProtectionViewController {
         selectNetworkTrust(network: collection[indexPath.section][indexPath.row], sourceView: view) { trust in
             let network = self.collection[indexPath.section][indexPath.row]
             if Application.shared.connectionManager.needToReconnect(network: network, newTrust: trust) {
-                self.showReconnectPrompt {
-                    self.trustSelected(trust: trust, indexPath: indexPath)
-                    Application.shared.connectionManager.reconnect()
+                if let cell = tableView.cellForRow(at: indexPath) {
+                    self.showReconnectPrompt(sourceView: cell as UIView) {
+                        self.trustSelected(trust: trust, indexPath: indexPath)
+                        Application.shared.connectionManager.reconnect()
+                    }
                 }
             } else {
                 self.trustSelected(trust: trust, indexPath: indexPath)

--- a/IVPNClient/Utilities/Extensions/UIViewController+Ext.swift
+++ b/IVPNClient/Utilities/Extensions/UIViewController+Ext.swift
@@ -162,13 +162,13 @@ extension UIViewController {
         }
     }
     
-    func showReconnectPrompt(confirmed: @escaping () -> Void) {
+    func showReconnectPrompt(sourceView: UIView, confirmed: @escaping () -> Void) {
         guard !UserDefaults.shared.notAskToReconnect else {
             confirmed()
             return
         }
         
-        showActionSheet(title: "To apply the new settings, IVPN needs to be reconnected.", actions: ["Reconnect", "Reconnect + Don't ask next time"], sourceView: view) { index in
+        showActionSheet(title: "To apply the new settings, IVPN needs to be reconnected.", actions: ["Reconnect", "Reconnect + Don't ask next time"], sourceView: sourceView) { index in
             switch index {
             case 0:
                 confirmed()


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the new behavior?

UI issue described in #64 is now fixed.