### PR TITLE
Add NSLocalNetworkUsageDescription text in Info.plist

### DIFF
--- a/IVPNClient/Info.plist
+++ b/IVPNClient/Info.plist
@@ -65,6 +65,8 @@
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>Used to scan QR codes</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>We need to use your Local Network to obtain IVPN servers latency.</string>
 	<key>SentryDsn</key>
 	<string>$(SentryDsn)</string>
 	<key>TlsHostName</key>


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

iOS presents the default text in the "#app name# would like to find and connect to devices on your local network." iOS 14 privacy alert.

## What is the new behavior?

Added `NSLocalNetworkUsageDescription` text in Info.plist:
"We need to use your Local Network to obtain IVPN servers latency."

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
