### PR TITLE
Mismatch when connecting to disabled server

### DIFF
--- a/IVPNClient/Scenes/MainScreen/ControlPanel/ControlPanelViewController.swift
+++ b/IVPNClient/Scenes/MainScreen/ControlPanel/ControlPanelViewController.swift
@@ -416,8 +416,7 @@ class ControlPanelViewController: UITableViewController {
     }
     
     @objc private func pingDidComplete() {
-        Application.shared.connectionManager.needsToUpdateSelectedServer()
-        controlPanelView.updateServerNames()
+        serverSelected()
         
         if needsToReconnect {
             needsToReconnect = false


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the current behavior?

Issue number: #71

## What is the new behavior?

- Fixed server mismatch issue when VPN is connected by iOS due to saved on-demand rules. Eg. device connects to untrusted network, after app changes selected server with servers latency check.