### PR TITLE
Incorrect subscription expiration alert

### DIFF
--- a/IVPNClient/Models/ServiceStatus.swift
+++ b/IVPNClient/Models/ServiceStatus.swift
@@ -111,4 +111,9 @@ struct ServiceStatus: Codable {
         return activeUntil != nil && (activeUntil ?? 0) > 0
     }
     
+    func activeUntilExpired() -> Bool {
+        let activeUntilDate = Date(timeIntervalSince1970: TimeInterval(activeUntil ?? 0))
+        return Date() > activeUntilDate
+    }
+    
 }

--- a/IVPNClient/ViewModels/InfoAlertViewModel.swift
+++ b/IVPNClient/ViewModels/InfoAlertViewModel.swift
@@ -28,11 +28,22 @@ class InfoAlertViewModel {
     // MARK: - Properties -
     
     var text: String {
-        let days = Application.shared.serviceStatus.daysUntilSubscriptionExpiration()
+        
         switch infoAlert {
         case .subscriptionExpiration:
+            let days = Application.shared.serviceStatus.daysUntilSubscriptionExpiration()
+            let activeUntilExpired = Application.shared.serviceStatus.activeUntilExpired()
+            
             if days == 0 {
+                if !activeUntilExpired {
+                    return "Subscription expires today"
+                }
+                
                 return "Subscription expired"
+            }
+            
+            if days == 1 {
+                return "Subscription will expire in \(days) day"
             }
             
             return "Subscription will expire in \(days) days"


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When the subscription expires "today", but it's still active, the iOS app shows incorrectly the alert "Subscription expired RENEW".

Issue number: #104

## What is the new behavior?

Resolves #104 
