### PR TITLE
Add DNS resolver validation error in the UI

### DIFF
--- a/IVPNClient/Managers/DNSManager.swift
+++ b/IVPNClient/Managers/DNSManager.swift
@@ -32,10 +32,8 @@ class DNSManager {
     static let shared = DNSManager()
     
     var isEnabled: Bool {
-        return manager.isEnabled
+        return NEDNSSettingsManager.shared().isEnabled
     }
-    
-    private let manager = NEDNSSettingsManager.shared()
     
     // MARK: - Initialize -
     
@@ -54,23 +52,25 @@ class DNSManager {
             return
         }
         
-        manager.loadFromPreferences { error in
-            self.manager.dnsSettings = self.getDnsSettings(model: model)
-            self.manager.onDemandRules = self.getOnDemandRules(model: model)
-            self.manager.saveToPreferences { error in
-                completion(error)
+        NEDNSSettingsManager.shared().loadFromPreferences { _ in
+            NEDNSSettingsManager.shared().removeFromPreferences { _ in
+                NEDNSSettingsManager.shared().dnsSettings = self.getDnsSettings(model: model)
+                NEDNSSettingsManager.shared().onDemandRules = self.getOnDemandRules(model: model)
+                NEDNSSettingsManager.shared().saveToPreferences { error in
+                    completion(error)
+                }
             }
         }
     }
     
     func loadProfile(completion: @escaping (Error?) -> Void) {
-        manager.loadFromPreferences { error in
+        NEDNSSettingsManager.shared().loadFromPreferences { error in
             completion(error)
         }
     }
     
     func removeProfile(completion: @escaping (Error?) -> Void) {
-        manager.removeFromPreferences { error in
+        NEDNSSettingsManager.shared().removeFromPreferences { error in
             completion(error)
         }
     }

--- a/IVPNClient/Managers/DNSManager.swift
+++ b/IVPNClient/Managers/DNSManager.swift
@@ -76,6 +76,10 @@ class DNSManager {
     }
     
     static func saveResolvedDNS(server: String, key: String) {
+        guard !server.trim().isEmpty else {
+            return
+        }
+        
         DNSResolver.resolve(host: server) { list in
             var addresses: [String] = []
             

--- a/IVPNClient/Managers/DNSManager.swift
+++ b/IVPNClient/Managers/DNSManager.swift
@@ -95,6 +95,10 @@ class DNSManager {
             default:
                 break
             }
+            
+            if addresses.isEmpty {
+                NotificationCenter.default.post(name: Notification.Name.ResolvedDNSError, object: nil)
+            }
         }
     }
     

--- a/IVPNClient/Scenes/SecureDNS/SecureDNSViewController.swift
+++ b/IVPNClient/Scenes/SecureDNS/SecureDNSViewController.swift
@@ -75,6 +75,7 @@ class SecureDNSViewController: UITableViewController {
         secureDNSView.setupView(model: model)
         addObservers()
         hideKeyboardOnTap()
+        saveAddress()
     }
     
     // MARK: - Methods -

--- a/IVPNClient/Scenes/SecureDNS/SecureDNSViewController.swift
+++ b/IVPNClient/Scenes/SecureDNS/SecureDNSViewController.swift
@@ -159,12 +159,14 @@ class SecureDNSViewController: UITableViewController {
         
         server = DNSProtocolType.sanitizeServer(address: server)
         model.address = server
-        secureDNSView.setupView(model: model)
         
         if server.isEmpty {
+            UserDefaults.standard.set([], forKey: UserDefaults.Key.resolvedDNSOutsideVPN)
             removeDNSProfile()
             secureDNSView.enableSwitch.setOn(false, animated: true)
         }
+        
+        secureDNSView.setupView(model: model)
     }
     
 }

--- a/IVPNClient/Scenes/SecureDNS/SecureDNSViewController.swift
+++ b/IVPNClient/Scenes/SecureDNS/SecureDNSViewController.swift
@@ -75,6 +75,8 @@ class SecureDNSViewController: UITableViewController {
         secureDNSView.setupView(model: model)
         addObservers()
         hideKeyboardOnTap()
+        
+        #warning("Added to resolve upgrade disruption from 2.3.0 to 2.3.1")
         saveAddress()
     }
     

--- a/IVPNClient/Scenes/SecureDNS/SecureDNSViewController.swift
+++ b/IVPNClient/Scenes/SecureDNS/SecureDNSViewController.swift
@@ -93,6 +93,7 @@ class SecureDNSViewController: UITableViewController {
     
     private func addObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(updateDNSProfile), name: Notification.Name.UpdateResolvedDNS, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(showResolvedDNSError), name: Notification.Name.ResolvedDNSError, object: nil)
     }
     
     private func saveDNSProfile() {

--- a/IVPNClient/Scenes/SecureDNS/SecureDNSViewController.swift
+++ b/IVPNClient/Scenes/SecureDNS/SecureDNSViewController.swift
@@ -173,8 +173,11 @@ class SecureDNSViewController: UITableViewController {
     }
     
     @objc private func resolvedDNSError() {
+        secureDNSView.serverField.text = ""
+        model.address = ""
         removeDNSProfile()
         secureDNSView.enableSwitch.setOn(false, animated: true)
+        secureDNSView.setupView(model: model)
         showResolvedDNSError()
     }
     

--- a/IVPNClient/Scenes/SecureDNS/SecureDNSViewController.swift
+++ b/IVPNClient/Scenes/SecureDNS/SecureDNSViewController.swift
@@ -96,7 +96,7 @@ class SecureDNSViewController: UITableViewController {
     
     private func addObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(updateDNSProfile), name: Notification.Name.UpdateResolvedDNS, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(showResolvedDNSError), name: Notification.Name.ResolvedDNSError, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(resolvedDNSError), name: Notification.Name.ResolvedDNSError, object: nil)
     }
     
     private func saveDNSProfile() {
@@ -170,6 +170,12 @@ class SecureDNSViewController: UITableViewController {
         }
         
         secureDNSView.setupView(model: model)
+    }
+    
+    @objc private func resolvedDNSError() {
+        removeDNSProfile()
+        secureDNSView.enableSwitch.setOn(false, animated: true)
+        showResolvedDNSError()
     }
     
 }

--- a/IVPNClient/Scenes/ViewControllers/CustomDNSViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/CustomDNSViewController.swift
@@ -74,6 +74,8 @@ class CustomDNSViewController: UITableViewController {
         hideKeyboardOnTap()
         setupView()
         addObservers()
+        
+        #warning("Added to resolve upgrade disruption from 2.3.0 to 2.3.1")
         saveAddress()
     }
     

--- a/IVPNClient/Scenes/ViewControllers/CustomDNSViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/CustomDNSViewController.swift
@@ -102,12 +102,14 @@ class CustomDNSViewController: UITableViewController {
         }
         
         UserDefaults.shared.set(server, forKey: UserDefaults.Key.customDNS)
-        setupView()
         
         if server.isEmpty {
             UserDefaults.shared.set(false, forKey: UserDefaults.Key.isCustomDNS)
+            UserDefaults.shared.set([], forKey: UserDefaults.Key.resolvedDNSInsideVPN)
             customDNSSwitch.setOn(false, animated: true)
         }
+        
+        setupView()
     }
     
     @objc func updateResolvedDNS() {

--- a/IVPNClient/Scenes/ViewControllers/CustomDNSViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/CustomDNSViewController.swift
@@ -144,8 +144,11 @@ class CustomDNSViewController: UITableViewController {
     }
     
     @objc private func resolvedDNSError() {
+        customDNSTextField.text = ""
+        UserDefaults.shared.set("", forKey: UserDefaults.Key.customDNS)
         UserDefaults.shared.set(false, forKey: UserDefaults.Key.isCustomDNS)
         customDNSSwitch.setOn(false, animated: true)
+        setupView()
         showResolvedDNSError()
     }
     

--- a/IVPNClient/Scenes/ViewControllers/CustomDNSViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/CustomDNSViewController.swift
@@ -125,7 +125,7 @@ class CustomDNSViewController: UITableViewController {
     
     private func addObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(updateResolvedDNS), name: Notification.Name.UpdateResolvedDNSInsideVPN, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(showResolvedDNSError), name: Notification.Name.ResolvedDNSError, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(resolvedDNSError), name: Notification.Name.ResolvedDNSError, object: nil)
     }
     
     private func setupView() {
@@ -141,6 +141,12 @@ class CustomDNSViewController: UITableViewController {
         typeControl.isEnabled = preferred != .plain
         typeControl.selectedSegmentIndex = preferred == .dot ? 1 : 0
         updateResolvedDNS()
+    }
+    
+    @objc private func resolvedDNSError() {
+        UserDefaults.shared.set(false, forKey: UserDefaults.Key.isCustomDNS)
+        customDNSSwitch.setOn(false, animated: true)
+        showResolvedDNSError()
     }
     
 }

--- a/IVPNClient/Scenes/ViewControllers/CustomDNSViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/CustomDNSViewController.swift
@@ -120,6 +120,7 @@ class CustomDNSViewController: UITableViewController {
     
     private func addObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(updateResolvedDNS), name: Notification.Name.UpdateResolvedDNSInsideVPN, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(showResolvedDNSError), name: Notification.Name.ResolvedDNSError, object: nil)
     }
     
     private func setupView() {

--- a/IVPNClient/Scenes/ViewControllers/CustomDNSViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/CustomDNSViewController.swift
@@ -74,6 +74,7 @@ class CustomDNSViewController: UITableViewController {
         hideKeyboardOnTap()
         setupView()
         addObservers()
+        saveAddress()
     }
     
     // MARK: - Methods -

--- a/IVPNClient/Scenes/ViewControllers/ProtocolViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/ProtocolViewController.swift
@@ -317,9 +317,13 @@ extension ProtocolViewController {
             }
         }
         
-        if connectionProtocol.tunnelType() == .ipsec {
-            if #available(iOS 14.0, *) {
-                DNSManager.shared.removeProfile { _ in }
+        if #available(iOS 14.0, *) {
+            if connectionProtocol.tunnelType() == .ipsec {
+                DNSManager.shared.removeProfile { _ in
+                    DNSManager.shared.loadProfile { _ in
+                        
+                    }
+                }
             }
         }
         

--- a/IVPNClient/Utilities/Extensions/NotificationName+Ext.swift
+++ b/IVPNClient/Utilities/Extensions/NotificationName+Ext.swift
@@ -51,5 +51,6 @@ extension Notification.Name {
     public static let UpdateGeoLocation = Notification.Name("updateGeoLocation")
     public static let UpdateResolvedDNS = Notification.Name("updateResolvedDNS")
     public static let UpdateResolvedDNSInsideVPN = Notification.Name("updateResolvedDNSInsideVPN")
+    public static let ResolvedDNSError = Notification.Name("resolvedDNSError")
     
 }

--- a/IVPNClient/Utilities/Extensions/UIViewController+Ext.swift
+++ b/IVPNClient/Utilities/Extensions/UIViewController+Ext.swift
@@ -190,6 +190,10 @@ extension UIViewController {
         }
     }
     
+    @objc func showResolvedDNSError() {
+        showErrorAlert(title: "Error", message: "Failed to resolve IP addresses for DNS server")
+    }
+    
 }
 
 // MARK: - Presenter -

--- a/IVPNClient/Utilities/Extensions/URL+Ext.swift
+++ b/IVPNClient/Utilities/Extensions/URL+Ext.swift
@@ -33,7 +33,7 @@ extension URL {
             
             if count > 2 {
                 domainName = subStrings[count - 3] + "." + subStrings[count - 2] + "." + subStrings[count - 1]
-            } else if count == 2 {
+            } else if count <= 2 {
                 domainName = hostName
             }
             

--- a/UnitTests/Enum/DNSProtocolTypeTests.swift
+++ b/UnitTests/Enum/DNSProtocolTypeTests.swift
@@ -130,6 +130,9 @@ class DNSProtocolTypeTests: XCTestCase {
         
         server = DNSProtocolType.getServerToResolve(address: "subdomain.subdomain.example.com")
         XCTAssertEqual(server, "subdomain.example.com")
+        
+        server = DNSProtocolType.getServerToResolve(address: "example")
+        XCTAssertEqual(server, "example")
     }
     
     func test_sanitizeServer() {


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## What is the new behavior?

When entering hostname for DoH or DoT settings, iOS device resolves IP addresses from hostname, as an array of IP addresses is required to enable custom DNS configuration.
If DNS resolver fails, an error alert is presented in the UI.

Resolves #115