### PR TITLE
Show gateways without IPv6 support

### DIFF
--- a/IVPNClient/Managers/ConnectionManager.swift
+++ b/IVPNClient/Managers/ConnectionManager.swift
@@ -347,6 +347,12 @@ class ConnectionManager {
     
     func updateSelectedServer(status: NEVPNStatus? = nil) {
         guard Application.shared.settings.selectedServer.fastest else {
+            if !UserDefaults.standard.showIPv4Servers && Application.shared.serverList.getServer(byGateway: Application.shared.settings.selectedServer.gateway) == nil {
+                if let server = Application.shared.serverList.getServers().first {
+                    Application.shared.settings.selectedServer = server
+                }
+            }
+            
             return
         }
         

--- a/IVPNClient/Models/Settings.swift
+++ b/IVPNClient/Models/Settings.swift
@@ -95,10 +95,11 @@ class Settings {
     
     func updateSelectedServerForMultiHop(isEnabled: Bool) {
         if isEnabled && Application.shared.settings.selectedServer.fastest {
-            let server = Application.shared.serverList.servers.first!
-            server.fastest = false
-            Application.shared.settings.selectedServer = server
-            Application.shared.settings.selectedExitServer = Application.shared.serverList.getExitServer(entryServer: server)
+            if let server = Application.shared.serverList.getServers().first {
+                server.fastest = false
+                Application.shared.settings.selectedServer = server
+                Application.shared.settings.selectedExitServer = Application.shared.serverList.getExitServer(entryServer: server)
+            }
         }
         
         if !isEnabled {

--- a/IVPNClient/Models/VPNServer.swift
+++ b/IVPNClient/Models/VPNServer.swift
@@ -59,7 +59,13 @@ class VPNServer {
     }
     
     var supportsIPv6: Bool {
-        return hosts.first?.ipv6 != nil
+        for host in hosts {
+            if !(host.ipv6?.localIP.isEmpty ?? true) {
+                return true
+            }
+        }
+        
+        return false
     }
     
     private (set) var gateway: String

--- a/IVPNClient/Models/VPNServer.swift
+++ b/IVPNClient/Models/VPNServer.swift
@@ -58,6 +58,10 @@ class VPNServer {
         return CLLocation(latitude: latitude, longitude: longitude)
     }
     
+    var supportsIPv6: Bool {
+        return hosts.first?.ipv6 != nil
+    }
+    
     private (set) var gateway: String
     private (set) var countryCode: String
     private (set) var country: String

--- a/IVPNClient/Models/VPNServerList.swift
+++ b/IVPNClient/Models/VPNServerList.swift
@@ -33,7 +33,7 @@ class VPNServerList {
     open private(set) var servers: [VPNServer]
     
     var filteredFastestServers: [VPNServer] {
-        var serversArray = servers
+        var serversArray = getServers()
         let fastestServerConfigured = UserDefaults.standard.bool(forKey: UserDefaults.Key.fastestServerConfigured)
         
         if fastestServerConfigured {
@@ -160,6 +160,10 @@ class VPNServerList {
     
     func getServers() -> [VPNServer] {
         guard UserDefaults.standard.showIPv4Servers else {
+            if let server = servers.last {
+                return [server]
+            }
+            
             return servers.filter { (server: VPNServer) -> Bool in
                 return server.hosts.first?.ipv6 != nil
             }
@@ -169,15 +173,15 @@ class VPNServerList {
     }
     
     func getServer(byIpAddress ipAddress: String) -> VPNServer? {
-        return servers.first { $0.ipAddresses.first { $0 == ipAddress } != nil }
+        return getServers().first { $0.ipAddresses.first { $0 == ipAddress } != nil }
     }
     
     func getServer(byGateway gateway: String) -> VPNServer? {
-        return servers.first { $0.gateway == gateway }
+        return getServers().first { $0.gateway == gateway }
     }
     
     func getServer(byCity city: String) -> VPNServer? {
-        return servers.first { $0.city == city }
+        return getServers().first { $0.city == city }
     }
     
     func getFastestServer() -> VPNServer? {

--- a/IVPNClient/Models/VPNServerList.swift
+++ b/IVPNClient/Models/VPNServerList.swift
@@ -161,7 +161,7 @@ class VPNServerList {
     func getServers() -> [VPNServer] {
         guard UserDefaults.standard.showIPv4Servers || !UserDefaults.standard.isIPv6 else {
             return servers.filter { (server: VPNServer) -> Bool in
-                return server.hosts.first?.ipv6 != nil
+                return server.supportsIPv6
             }
         }
         

--- a/IVPNClient/Models/VPNServerList.swift
+++ b/IVPNClient/Models/VPNServerList.swift
@@ -160,10 +160,6 @@ class VPNServerList {
     
     func getServers() -> [VPNServer] {
         guard UserDefaults.standard.showIPv4Servers else {
-            if let server = servers.last {
-                return [server]
-            }
-            
             return servers.filter { (server: VPNServer) -> Bool in
                 return server.hosts.first?.ipv6 != nil
             }

--- a/IVPNClient/Models/VPNServerList.swift
+++ b/IVPNClient/Models/VPNServerList.swift
@@ -158,6 +158,14 @@ class VPNServerList {
         return FileSystemManager.pathToDocumentFile(Config.serversListCacheFileName)
     }()
     
+    func getServers() -> [VPNServer] {
+        let filteredServers = servers.filter { (server: VPNServer) -> Bool in
+            return server.hosts.first?.ipv6 != nil
+        }
+        
+        return filteredServers
+    }
+    
     func getServer(byIpAddress ipAddress: String) -> VPNServer? {
         return servers.first { $0.ipAddresses.first { $0 == ipAddress } != nil }
     }

--- a/IVPNClient/Models/VPNServerList.swift
+++ b/IVPNClient/Models/VPNServerList.swift
@@ -159,7 +159,7 @@ class VPNServerList {
     }()
     
     func getServers() -> [VPNServer] {
-        guard UserDefaults.standard.showIPv4Servers else {
+        guard UserDefaults.standard.showIPv4Servers || !UserDefaults.standard.isIPv6 else {
             return servers.filter { (server: VPNServer) -> Bool in
                 return server.hosts.first?.ipv6 != nil
             }

--- a/IVPNClient/Models/VPNServerList.swift
+++ b/IVPNClient/Models/VPNServerList.swift
@@ -159,11 +159,13 @@ class VPNServerList {
     }()
     
     func getServers() -> [VPNServer] {
-        let filteredServers = servers.filter { (server: VPNServer) -> Bool in
-            return server.hosts.first?.ipv6 != nil
+        guard UserDefaults.standard.showIPv4Servers else {
+            return servers.filter { (server: VPNServer) -> Bool in
+                return server.hosts.first?.ipv6 != nil
+            }
         }
         
-        return filteredServers
+        return servers
     }
     
     func getServer(byIpAddress ipAddress: String) -> VPNServer? {

--- a/IVPNClient/Scenes/Base.lproj/Main.storyboard
+++ b/IVPNClient/Scenes/Base.lproj/Main.storyboard
@@ -20,7 +20,7 @@
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <color key="sectionIndexBackgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="zK0-8u-72W">
-                            <rect key="frame" x="0.0" y="1169.5" width="414" height="65"/>
+                            <rect key="frame" x="0.0" y="1192.5" width="414" height="65"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VERSION 0.0.0 (0)" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gBW-V1-BW0">
@@ -216,7 +216,7 @@
                                                         <action selector="toggleIpv6:" destination="5KC-W6-t9Q" eventType="valueChanged" id="q6l-ML-Y8E"/>
                                                     </connections>
                                                 </switch>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="IPv6 for VPN" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ehR-7G-CN0">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="IPv6 for WireGuard VPN" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ehR-7G-CN0">
                                                     <rect key="frame" x="16" y="10" width="321" height="20"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="20" id="VcE-fy-V7V"/>
@@ -245,12 +245,45 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="NetworkProtectionHeaderTableViewCell" rowHeight="44" id="aNF-yr-0mE">
+                                        <rect key="frame" x="0.0" y="419.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="aNF-yr-0mE" id="we2-JH-yXm">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hV9-LW-jwe">
+                                                    <rect key="frame" x="349" y="6.5" width="51" height="31"/>
+                                                    <color key="onTintColor" name="ivpnBlue"/>
+                                                    <connections>
+                                                        <action selector="toggleShowIPv4Servers:" destination="5KC-W6-t9Q" eventType="valueChanged" id="tho-4S-MpQ"/>
+                                                    </connections>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show servers without IPv6" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YgN-L8-nAy">
+                                                    <rect key="frame" x="16" y="12" width="321" height="20"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="20" id="KAU-GD-l7G"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" name="ivpnLabelPrimary"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="hV9-LW-jwe" firstAttribute="centerY" secondItem="we2-JH-yXm" secondAttribute="centerY" id="82z-vl-Yj5"/>
+                                                <constraint firstItem="YgN-L8-nAy" firstAttribute="leading" secondItem="we2-JH-yXm" secondAttribute="leading" constant="16" id="Tbr-4a-Gw9"/>
+                                                <constraint firstItem="YgN-L8-nAy" firstAttribute="centerY" secondItem="we2-JH-yXm" secondAttribute="centerY" id="bnr-2h-0kQ"/>
+                                                <constraint firstAttribute="trailing" secondItem="hV9-LW-jwe" secondAttribute="trailing" constant="16" id="gSX-Rc-L1F"/>
+                                                <constraint firstItem="hV9-LW-jwe" firstAttribute="leading" secondItem="YgN-L8-nAy" secondAttribute="trailing" constant="12" id="rTp-KN-fnC"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Advanced settings" id="VPy-ja-Hns">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="80" id="ga8-ba-ASK">
-                                        <rect key="frame" x="0.0" y="475.5" width="414" height="80"/>
+                                        <rect key="frame" x="0.0" y="519.5" width="414" height="80"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ga8-ba-ASK" id="svz-0C-ckf">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="80"/>
@@ -288,7 +321,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="60" id="YMM-DT-Evy">
-                                        <rect key="frame" x="0.0" y="555.5" width="414" height="60"/>
+                                        <rect key="frame" x="0.0" y="599.5" width="414" height="60"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="YMM-DT-Evy" id="0AD-JA-JTl">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="60"/>
@@ -326,7 +359,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="80" id="SJt-iu-O9l">
-                                        <rect key="frame" x="0.0" y="615.5" width="414" height="80"/>
+                                        <rect key="frame" x="0.0" y="659.5" width="414" height="80"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SJt-iu-O9l" id="xQd-RB-eLG">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="80"/>
@@ -364,7 +397,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="80" id="uhH-uF-8qQ">
-                                        <rect key="frame" x="0.0" y="695.5" width="414" height="80"/>
+                                        <rect key="frame" x="0.0" y="739.5" width="414" height="80"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uhH-uF-8qQ" id="7hz-yV-k4b">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="80"/>
@@ -402,7 +435,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="NetworkProtectionHeaderTableViewCell" rowHeight="84" id="i3p-DL-4qb">
-                                        <rect key="frame" x="0.0" y="775.5" width="414" height="84"/>
+                                        <rect key="frame" x="0.0" y="819.5" width="414" height="84"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="i3p-DL-4qb" id="yBb-5g-Cgo">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="84"/>
@@ -445,7 +478,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="60" id="71h-Rn-GiM">
-                                        <rect key="frame" x="0.0" y="859.5" width="414" height="60"/>
+                                        <rect key="frame" x="0.0" y="903.5" width="414" height="60"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="71h-Rn-GiM" id="no5-dR-veT">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="60"/>
@@ -490,14 +523,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="44" id="OOg-Pf-x1z">
-                                        <rect key="frame" x="0.0" y="919.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="963.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="OOg-Pf-x1z" id="6Oa-Do-RYN">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Send Logs" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jpg-3d-dAU">
-                                                    <rect key="frame" x="16" y="0.0" width="378" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="390" height="44"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="44" id="sRF-HA-OGZ"/>
                                                     </constraints>
@@ -519,7 +552,7 @@
                             <tableViewSection headerTitle="About" id="S95-kF-m2f">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="44" id="jRI-M6-wda">
-                                        <rect key="frame" x="0.0" y="1019.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="1063.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="jRI-M6-wda" id="zNB-rZ-BcC">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
@@ -544,7 +577,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="44" id="QbD-lg-XeY">
-                                        <rect key="frame" x="0.0" y="1063.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="1107.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="QbD-lg-XeY" id="AR6-tI-Bcz">
                                             <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
@@ -569,7 +602,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="44" id="9id-BQ-0Os">
-                                        <rect key="frame" x="0.0" y="1107.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="1151.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="9id-BQ-0Os" id="ort-dt-Pcw">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -620,6 +653,7 @@
                         <outlet property="selectedProtocol" destination="R5e-Wk-dkz" id="aFg-ce-fcQ"/>
                         <outlet property="selectedServerFlag" destination="Dq7-2f-uog" id="RhA-Wq-cGd"/>
                         <outlet property="selectedServerName" destination="CPE-CP-JAE" id="l57-wo-Jil"/>
+                        <outlet property="showIPv4ServersSwitch" destination="hV9-LW-jwe" id="NzW-gv-njt"/>
                         <outlet property="versionLabel" destination="gBW-V1-BW0" id="Xo2-nd-tuj"/>
                         <segue destination="C8Y-kZ-eYV" kind="show" identifier="SelectProtocol" id="oZ9-fT-UYA"/>
                     </connections>
@@ -1369,14 +1403,14 @@
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="ProtocolTableViewCell" id="HtI-Zu-PMl" customClass="ProtocolTableViewCell" customModule="IVPNClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="55.5" width="414" height="43"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="HtI-Zu-PMl" id="xBM-uI-V8V">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="weu-7I-qbg">
-                                            <rect key="frame" x="16" y="14" width="361" height="16"/>
+                                            <rect key="frame" x="16" y="13.5" width="361" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="K4t-rv-8Rj"/>
                                             </constraints>
@@ -1385,7 +1419,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Protocol Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WQ9-eM-bEA">
-                                            <rect key="frame" x="16" y="11" width="359" height="21.5"/>
+                                            <rect key="frame" x="16" y="11" width="359" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" name="ivpnLabelPrimary"/>
                                             <nil key="highlightedColor"/>
@@ -1407,7 +1441,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="WireGuardRegenerationRateCell" rowHeight="60" id="JLp-oZ-cVy" customClass="WireGuardRegenerationRateCell" customModule="IVPNClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="99" width="414" height="60"/>
+                                <rect key="frame" x="0.0" y="98.5" width="414" height="60"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="JLp-oZ-cVy" id="Y7T-PJ-VmA">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="60"/>

--- a/IVPNClient/Scenes/MainScreen/Map/MapScrollView.swift
+++ b/IVPNClient/Scenes/MainScreen/Map/MapScrollView.swift
@@ -147,7 +147,7 @@ class MapScrollView: UIScrollView {
     }
     
     private func initServerLocationMarkers() {
-        for server in Application.shared.serverList.servers {
+        for server in Application.shared.serverList.getServers() {
             placeMarker(latitude: server.latitude, longitude: server.longitude, city: server.city)
         }
     }
@@ -353,7 +353,7 @@ class MapScrollView: UIScrollView {
     private func getNearByServers(server selectedServer: VPNServer) -> [VPNServer] {
         var servers = Application.shared.serverList.validateServer(firstServer: Application.shared.settings.selectedServer, secondServer: selectedServer) ? [selectedServer] : []
         
-        for server in Application.shared.serverList.servers {
+        for server in Application.shared.serverList.getServers() {
             guard server !== selectedServer else { continue }
             guard Application.shared.serverList.validateServer(firstServer: Application.shared.settings.selectedServer, secondServer: server) else { continue }
             

--- a/IVPNClient/Scenes/MainScreen/Map/MapScrollView.swift
+++ b/IVPNClient/Scenes/MainScreen/Map/MapScrollView.swift
@@ -56,7 +56,6 @@ class MapScrollView: UIScrollView {
     var localCoordinates: (Double, Double)?
     var currentCoordinates: (Double, Double)?
     
-    private var markers: [UIButton] = []
     private var connectToServerPopup = ConnectToServerPopupView()
     
     // MARK: - View lifecycle -
@@ -134,6 +133,7 @@ class MapScrollView: UIScrollView {
     private func addObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(updateMapPositionToSelectedServer), name: Notification.Name.ShowConnectToServerPopup, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(hideConnectToServerPopup), name: Notification.Name.HideConnectToServerPopup, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(reloadMarkers), name: Notification.Name.ServersListUpdated, object: nil)
     }
     
     private func initGestures() {
@@ -150,6 +150,8 @@ class MapScrollView: UIScrollView {
         for server in Application.shared.serverList.getServers() {
             placeMarker(latitude: server.latitude, longitude: server.longitude, city: server.city)
         }
+        
+        sendSubviewToBack(mapImageView)
     }
     
     private func initMarkers() {
@@ -266,11 +268,11 @@ class MapScrollView: UIScrollView {
         button.setTitleColor(UIColor.init(named: Theme.ivpnGray21), for: .normal)
         button.titleLabel?.font = .systemFont(ofSize: 10, weight: .regular)
         button.addTarget(self, action: #selector(selectServer), for: .touchUpInside)
+        button.tag = 1
         
         let marker = UIView(frame: CGRect(x: 50 - 3, y: 18, width: 6, height: 6))
         marker.layer.cornerRadius = 3
         marker.backgroundColor = UIColor.init(named: Theme.ivpnGray21)
-        marker.tag = 1
         
         if city == "Bratislava" {
             button.titleEdgeInsets = UIEdgeInsets(top: 21, left: 59, bottom: 0, right: 0)
@@ -292,8 +294,20 @@ class MapScrollView: UIScrollView {
         
         button.addSubview(marker)
         addSubview(button)
-        
-        markers.append(button)
+        sendSubviewToBack(button)
+    }
+    
+    private func removeMarkers() {
+        subviews.forEach {
+            if $0.tag == 1 {
+                $0.removeFromSuperview()
+            }
+        }
+    }
+    
+    @objc private func reloadMarkers() {
+        removeMarkers()
+        initServerLocationMarkers()
     }
     
     @objc private func selectServer(_ sender: UIButton) {

--- a/IVPNClient/Scenes/ViewControllers/ServerViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/ServerViewController.swift
@@ -45,7 +45,7 @@ class ServerViewController: UITableViewController {
         if isSearchActive {
             list = filteredCollection
         } else {
-            list = Application.shared.serverList.servers
+            list = Application.shared.serverList.getServers()
         }
         
         list.insert(VPNServer(gateway: "", countryCode: "", country: "", city: "", fastest: false), at: 0)
@@ -273,7 +273,7 @@ extension ServerViewController {
 extension ServerViewController: UISearchBarDelegate {
     
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        let collection = Application.shared.serverList.servers
+        let collection = Application.shared.serverList.getServers()
         
         filteredCollection.removeAll(keepingCapacity: false)
         filteredCollection = collection.filter { (server: VPNServer) -> Bool in

--- a/IVPNClient/Scenes/ViewControllers/ServersConfigurationTableViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/ServersConfigurationTableViewController.swift
@@ -27,7 +27,7 @@ class ServersConfigurationTableViewController: UITableViewController {
     
     // MARK: - Properties -
     
-    var collection = Application.shared.serverList.servers
+    var collection = Application.shared.serverList.getServers()
     
     // MARK: - View Lifecycle -
     

--- a/IVPNClient/Scenes/ViewControllers/SettingsViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/SettingsViewController.swift
@@ -128,6 +128,7 @@ class SettingsViewController: UITableViewController {
     @IBAction func toggleShowIPv4Servers(_ sender: UISwitch) {
         UserDefaults.standard.set(sender.isOn, forKey: UserDefaults.Key.showIPv4Servers)
         NotificationCenter.default.post(name: Notification.Name.ServersListUpdated, object: nil)
+        Application.shared.connectionManager.needsToUpdateSelectedServer()
     }
     
     @IBAction func toggleKeepAlive(_ sender: UISwitch) {

--- a/IVPNClient/Scenes/ViewControllers/SettingsViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/SettingsViewController.swift
@@ -121,6 +121,7 @@ class SettingsViewController: UITableViewController {
         }
         
         UserDefaults.shared.set(sender.isOn, forKey: UserDefaults.Key.isIPv6)
+        showIPv4ServersSwitch.isEnabled = sender.isOn
     }
     
     @IBAction func toggleShowIPv4Servers(_ sender: UISwitch) {
@@ -211,6 +212,7 @@ class SettingsViewController: UITableViewController {
         
         if UserDefaults.shared.isIPv6 {
             ipv6Switch.setOn(true, animated: false)
+            showIPv4ServersSwitch.isEnabled = true
         }
         
         if UserDefaults.standard.showIPv4Servers {

--- a/IVPNClient/Scenes/ViewControllers/SettingsViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/SettingsViewController.swift
@@ -126,6 +126,7 @@ class SettingsViewController: UITableViewController {
     
     @IBAction func toggleShowIPv4Servers(_ sender: UISwitch) {
         UserDefaults.standard.set(sender.isOn, forKey: UserDefaults.Key.showIPv4Servers)
+        NotificationCenter.default.post(name: Notification.Name.ServersListUpdated, object: nil)
     }
     
     @IBAction func toggleKeepAlive(_ sender: UISwitch) {

--- a/IVPNClient/Scenes/ViewControllers/SettingsViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/SettingsViewController.swift
@@ -42,6 +42,7 @@ class SettingsViewController: UITableViewController {
     @IBOutlet weak var loggingSwitch: UISwitch!
     @IBOutlet weak var loggingCell: UITableViewCell!
     @IBOutlet weak var ipv6Switch: UISwitch!
+    @IBOutlet weak var showIPv4ServersSwitch: UISwitch!
     
     // MARK: - Properties -
     
@@ -98,10 +99,10 @@ class SettingsViewController: UITableViewController {
         }
         
         guard Application.shared.connectionManager.status.isDisconnected() else {
-            showConnectedAlert(message: "To change Multi-Hop settings, please first disconnect", sender: sender, completion: {
+            showConnectedAlert(message: "To change Multi-Hop settings, please first disconnect", sender: sender) {
                 sender.setOn(UserDefaults.shared.isMultiHop, animated: true)
                 self.tableView.reloadData()
-            })
+            }
             return
         }
         
@@ -112,14 +113,25 @@ class SettingsViewController: UITableViewController {
     }
     
     @IBAction func toggleIpv6(_ sender: UISwitch) {
+        guard Application.shared.connectionManager.status.isDisconnected() || Application.shared.settings.connectionProtocol.tunnelType() != .wireguard else {
+            showConnectedAlert(message: "To change IPv6 settings, please first disconnect", sender: sender) {
+                sender.setOn(UserDefaults.shared.isMultiHop, animated: true)
+            }
+            return
+        }
+        
         UserDefaults.shared.set(sender.isOn, forKey: UserDefaults.Key.isIPv6)
+    }
+    
+    @IBAction func toggleShowIPv4Servers(_ sender: UISwitch) {
+        UserDefaults.standard.set(sender.isOn, forKey: UserDefaults.Key.showIPv4Servers)
     }
     
     @IBAction func toggleKeepAlive(_ sender: UISwitch) {
         if !Application.shared.connectionManager.status.isDisconnected() {
-            showConnectedAlert(message: "To change Keep alive on sleep settings, please first disconnect", sender: sender, completion: {
+            showConnectedAlert(message: "To change Keep alive on sleep settings, please first disconnect", sender: sender) {
                 sender.setOn(UserDefaults.shared.keepAlive, animated: true)
-            })
+            }
             return
         }
         
@@ -199,6 +211,10 @@ class SettingsViewController: UITableViewController {
         
         if UserDefaults.shared.isIPv6 {
             ipv6Switch.setOn(true, animated: false)
+        }
+        
+        if UserDefaults.standard.showIPv4Servers {
+            showIPv4ServersSwitch.setOn(true, animated: false)
         }
         
         if !UserDefaults.shared.keepAlive {

--- a/IVPNClient/Scenes/ViewControllers/SettingsViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/SettingsViewController.swift
@@ -206,26 +206,12 @@ class SettingsViewController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        if UserDefaults.shared.isMultiHop {
-            multiHopSwitch.setOn(true, animated: false)
-        }
-        
-        if UserDefaults.shared.isIPv6 {
-            ipv6Switch.setOn(true, animated: false)
-            showIPv4ServersSwitch.isEnabled = true
-        }
-        
-        if UserDefaults.standard.showIPv4Servers {
-            showIPv4ServersSwitch.setOn(true, animated: false)
-        }
-        
-        if !UserDefaults.shared.keepAlive {
-            keepAliveSwitch.setOn(false, animated: false)
-        }
-        
-        if UserDefaults.shared.isLogging {
-            loggingSwitch.setOn(true, animated: false)
-        }
+        multiHopSwitch.setOn(UserDefaults.shared.isMultiHop, animated: false)
+        ipv6Switch.setOn(UserDefaults.shared.isIPv6, animated: false)
+        showIPv4ServersSwitch.setOn(UserDefaults.standard.showIPv4Servers, animated: false)
+        showIPv4ServersSwitch.isEnabled = UserDefaults.shared.isIPv6
+        keepAliveSwitch.setOn(UserDefaults.shared.keepAlive, animated: false)
+        loggingSwitch.setOn(UserDefaults.shared.isLogging, animated: false)
         
         updateCellInset(cell: entryServerCell, inset: UserDefaults.shared.isMultiHop)
         updateCellInset(cell: loggingCell, inset: UserDefaults.shared.isLogging)

--- a/IVPNClient/Utilities/Extensions/NotificationName+Ext.swift
+++ b/IVPNClient/Utilities/Extensions/NotificationName+Ext.swift
@@ -52,5 +52,6 @@ extension Notification.Name {
     public static let UpdateResolvedDNS = Notification.Name("updateResolvedDNS")
     public static let UpdateResolvedDNSInsideVPN = Notification.Name("updateResolvedDNSInsideVPN")
     public static let ResolvedDNSError = Notification.Name("resolvedDNSError")
+    public static let ServersListUpdated = Notification.Name("serversListUpdated")
     
 }

--- a/IVPNClient/Utilities/Extensions/UserDefaults+Ext.swift
+++ b/IVPNClient/Utilities/Extensions/UserDefaults+Ext.swift
@@ -77,6 +77,7 @@ extension UserDefaults {
         static let secureDNS = "SecureDNS"
         static let serviceStatus = "ServiceStatus"
         static let isIPv6 = "isIPv6"
+        static let showIPv4Servers = "showIPv4Servers"
     }
     
     @objc dynamic var wireguardTunnelProviderError: String {
@@ -199,6 +200,10 @@ extension UserDefaults {
         return bool(forKey: Key.isIPv6)
     }
     
+    @objc dynamic var showIPv4Servers: Bool {
+        return bool(forKey: Key.showIPv4Servers)
+    }
+    
     static func registerUserDefaults() {
         shared.register(defaults: [Key.networkProtectionUntrustedConnect: true])
         shared.register(defaults: [Key.networkProtectionTrustedDisconnect: true])
@@ -206,6 +211,7 @@ extension UserDefaults {
         shared.register(defaults: [Key.wgRegenerationRate: Config.wgKeyRegenerationRate])
         shared.register(defaults: [Key.wgKeyTimestamp: Date()])
         standard.register(defaults: [Key.selectedServerFastest: true])
+        standard.register(defaults: [Key.showIPv4Servers: true])
         shared.register(defaults: [Key.serversSort: "city"])
     }
     
@@ -227,6 +233,7 @@ extension UserDefaults {
         shared.removeObject(forKey: Key.isIPv6)
         standard.removeObject(forKey: Key.selectedServerFastest)
         standard.removeObject(forKey: Key.fastestServerConfigured)
+        standard.removeObject(forKey: Key.showIPv4Servers)
         standard.synchronize()
     }
     

--- a/IVPNClient/Utilities/Pinger/Pinger.swift
+++ b/IVPNClient/Utilities/Pinger/Pinger.swift
@@ -47,7 +47,7 @@ class Pinger {
         PingMannager.shared.pings = []
         UserDefaults.shared.set(Date().timeIntervalSince1970, forKey: "LastPingTimestamp")
         
-        for server in serverList.servers {
+        for server in serverList.getServers() {
             if let ipAddress = server.ipAddresses.first {
                 guard !ipAddress.isEmpty else { continue }
                 let ping = Ping()


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Description

New setting: show gateways without IPv6 support

This setting should be disabled (or hidden) and on by default.
When user enabled IPv6 for VPN tunnel, this setting should became visible.

Resolves #122
