### PR TITLE
Update WireGuard manual key rotation

### DIFF
--- a/IVPNClient/Managers/AppKeyManager.swift
+++ b/IVPNClient/Managers/AppKeyManager.swift
@@ -23,7 +23,7 @@
 
 import Foundation
 
-@objc protocol AppKeyManagerDelegate: class {
+@objc protocol AppKeyManagerDelegate: AnyObject {
     func setKeyStart()
     func setKeySuccess()
     func setKeyFail()

--- a/IVPNClient/Managers/AppKeyManager.swift
+++ b/IVPNClient/Managers/AppKeyManager.swift
@@ -88,11 +88,6 @@ class AppKeyManager {
         var interface = Interface()
         interface.privateKey = Interface.generatePrivateKey()
         
-        UserDefaults.shared.set(Date().changeDays(by: -50), forKey: UserDefaults.Key.wgKeyTimestamp)
-        KeyChain.wgPrivateKey = nil
-        KeyChain.wgPublicKey = nil
-        KeyChain.wgIpAddress = nil
-        
         let params = ApiService.authParams + [
             URLQueryItem(name: "public_key", value: interface.publicKey ?? "")
         ]

--- a/IVPNClient/Managers/AppKeyManager.swift
+++ b/IVPNClient/Managers/AppKeyManager.swift
@@ -91,6 +91,7 @@ class AppKeyManager {
         UserDefaults.shared.set(Date().changeDays(by: -50), forKey: UserDefaults.Key.wgKeyTimestamp)
         KeyChain.wgPrivateKey = nil
         KeyChain.wgPublicKey = nil
+        KeyChain.wgIpAddress = nil
         
         let params = ApiService.authParams + [
             URLQueryItem(name: "public_key", value: interface.publicKey ?? "")

--- a/IVPNClient/Managers/AppKeyManager.swift
+++ b/IVPNClient/Managers/AppKeyManager.swift
@@ -88,6 +88,10 @@ class AppKeyManager {
         var interface = Interface()
         interface.privateKey = Interface.generatePrivateKey()
         
+        UserDefaults.shared.set(Date().changeDays(by: -50), forKey: UserDefaults.Key.wgKeyTimestamp)
+        KeyChain.wgPrivateKey = nil
+        KeyChain.wgPublicKey = nil
+        
         let params = ApiService.authParams + [
             URLQueryItem(name: "public_key", value: interface.publicKey ?? "")
         ]

--- a/IVPNClient/Managers/SessionManager.swift
+++ b/IVPNClient/Managers/SessionManager.swift
@@ -23,7 +23,7 @@
 
 import Foundation
 
-@objc protocol SessionManagerDelegate: class {
+@objc protocol SessionManagerDelegate: AnyObject {
     func createSessionStart()
     func createSessionSuccess()
     func createSessionFailure(error: Any?)

--- a/IVPNClient/Managers/VPNErrorObserver.swift
+++ b/IVPNClient/Managers/VPNErrorObserver.swift
@@ -23,7 +23,7 @@
 
 import Foundation
 
-protocol VPNErrorObserverDelegate: class {
+protocol VPNErrorObserverDelegate: AnyObject {
     func presentError(title: String, message: String)
 }
 

--- a/IVPNClient/Scenes/MainScreen/ControlPanel/ControlPanelViewController+Ext.swift
+++ b/IVPNClient/Scenes/MainScreen/ControlPanel/ControlPanelViewController+Ext.swift
@@ -124,6 +124,7 @@ extension ControlPanelViewController {
     
     override func setKeyFail() {
         hud.dismiss()
+        controlPanelView.connectSwitch.setOn(false, animated: true)
         
         if AppKeyManager.isKeyExpired {
             showAlert(title: "Failed to automatically rotate WireGuard keys", message: "Cannot connect using WireGuard protocol: rotating WireGuard keys failed. This is likely because of no access to an IVPN API server. You can retry connection, rotate keys manually from preferences, or select another protocol. Please contact support if this error persists.")

--- a/IVPNClient/Scenes/MainScreen/Map/InfoAlertView.swift
+++ b/IVPNClient/Scenes/MainScreen/Map/InfoAlertView.swift
@@ -28,7 +28,7 @@ enum InfoAlertViewType {
     case info
 }
 
-protocol InfoAlertViewDelegate: class {
+protocol InfoAlertViewDelegate: AnyObject {
     func action()
 }
 

--- a/IVPNClient/Scenes/Signup/CaptchaViewController.swift
+++ b/IVPNClient/Scenes/Signup/CaptchaViewController.swift
@@ -23,7 +23,7 @@
 
 import UIKit
 
-protocol CaptchaViewControllerDelegate: class {
+protocol CaptchaViewControllerDelegate: AnyObject {
     func captchaSubmitted(code: String, captchaId: String)
 }
 

--- a/IVPNClient/Scenes/Signup/Scanner/ScannerViewController.swift
+++ b/IVPNClient/Scenes/Signup/Scanner/ScannerViewController.swift
@@ -24,7 +24,7 @@
 import AVFoundation
 import UIKit
 
-protocol ScannerViewControllerDelegate: class {
+protocol ScannerViewControllerDelegate: AnyObject {
     func qrCodeFound(code: String)
 }
 

--- a/IVPNClient/Scenes/Signup/TwoFactorViewController.swift
+++ b/IVPNClient/Scenes/Signup/TwoFactorViewController.swift
@@ -23,7 +23,7 @@
 
 import UIKit
 
-protocol TwoFactorViewControllerDelegate: class {
+protocol TwoFactorViewControllerDelegate: AnyObject {
     func codeSubmitted(code: String)
 }
 

--- a/IVPNClient/Scenes/TableCells/NetworkProtectionHeaderTableViewCell.swift
+++ b/IVPNClient/Scenes/TableCells/NetworkProtectionHeaderTableViewCell.swift
@@ -23,7 +23,7 @@
 
 import UIKit
 
-protocol NetworkProtectionHeaderTableViewCellDelegate: class {
+protocol NetworkProtectionHeaderTableViewCellDelegate: AnyObject {
     func toggle(isOn: Bool)
 }
 

--- a/IVPNClient/Scenes/TableCells/ServerConfigurationCell.swift
+++ b/IVPNClient/Scenes/TableCells/ServerConfigurationCell.swift
@@ -23,7 +23,7 @@
 
 import UIKit
 
-protocol ServerConfigurationCellDelegate: class {
+protocol ServerConfigurationCellDelegate: AnyObject {
     func toggle(isOn: Bool, gateway: String)
     func showValidation(error: String)
 }

--- a/IVPNClient/Scenes/ViewControllers/ServerViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/ServerViewController.swift
@@ -23,7 +23,7 @@
 
 import UIKit
 
-protocol ServerViewControllerDelegate: class {
+protocol ServerViewControllerDelegate: AnyObject {
     func reconnectToFastestServer()
 }
 

--- a/IVPNClient/Scenes/ViewControllers/WireGuardSettingsViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/WireGuardSettingsViewController.swift
@@ -77,16 +77,7 @@ class WireGuardSettingsViewController: UITableViewController {
     
     private func setupView() {
         ipAddressLabel.text = KeyChain.wgIpAddress
-        publicKeyLabel.text = KeyChain.wgPublicKey
-        
-        guard KeyChain.wgPublicKey != nil else {
-            keyTimestampLabel.text = ""
-            keyExpirationTimestampLabel.text = ""
-            keyRegenerationTimestampLabel.text = ""
-            
-            return
-        }
-        
+        publicKeyLabel.text = KeyChain.wgPublicKey        
         keyTimestampLabel.text = AppKeyManager.keyTimestamp.formatDate()
         keyExpirationTimestampLabel.text = AppKeyManager.keyExpirationTimestamp.formatDate()
         keyRegenerationTimestampLabel.text = AppKeyManager.keyRegenerationTimestamp.formatDate()

--- a/IVPNClient/Scenes/ViewControllers/WireGuardSettingsViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/WireGuardSettingsViewController.swift
@@ -77,7 +77,7 @@ class WireGuardSettingsViewController: UITableViewController {
     
     private func setupView() {
         ipAddressLabel.text = KeyChain.wgIpAddress
-        publicKeyLabel.text = KeyChain.wgPublicKey        
+        publicKeyLabel.text = KeyChain.wgPublicKey
         keyTimestampLabel.text = AppKeyManager.keyTimestamp.formatDate()
         keyExpirationTimestampLabel.text = AppKeyManager.keyExpirationTimestamp.formatDate()
         keyRegenerationTimestampLabel.text = AppKeyManager.keyRegenerationTimestamp.formatDate()

--- a/IVPNClient/Scenes/ViewControllers/WireGuardSettingsViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/WireGuardSettingsViewController.swift
@@ -78,6 +78,15 @@ class WireGuardSettingsViewController: UITableViewController {
     private func setupView() {
         ipAddressLabel.text = KeyChain.wgIpAddress
         publicKeyLabel.text = KeyChain.wgPublicKey
+        
+        guard KeyChain.wgPublicKey != nil else {
+            keyTimestampLabel.text = ""
+            keyExpirationTimestampLabel.text = ""
+            keyRegenerationTimestampLabel.text = ""
+            
+            return
+        }
+        
         keyTimestampLabel.text = AppKeyManager.keyTimestamp.formatDate()
         keyExpirationTimestampLabel.text = AppKeyManager.keyExpirationTimestamp.formatDate()
         keyRegenerationTimestampLabel.text = AppKeyManager.keyRegenerationTimestamp.formatDate()

--- a/IVPNClient/Scenes/ViewControllers/WireGuardSettingsViewController.swift
+++ b/IVPNClient/Scenes/ViewControllers/WireGuardSettingsViewController.swift
@@ -121,13 +121,13 @@ extension WireGuardSettingsViewController {
         hud.indicatorView = JGProgressHUDSuccessIndicatorView()
         hud.detailTextLabel.text = "WireGuard keys successfully regenerated and uploaded to IVPN server."
         hud.dismiss(afterDelay: 2)
-        
         setupView()
     }
     
     override func setKeyFail() {
         hud.dismiss()
         showAlert(title: "Failed to regenerate WireGuard keys", message: "There was a problem regenerating and uploading WireGuard keys to IVPN server.")
+        setupView()
     }
     
 }

--- a/wireguard-tunnel-provider/ExtensionKeyManager.swift
+++ b/wireguard-tunnel-provider/ExtensionKeyManager.swift
@@ -80,7 +80,6 @@ struct ExtensionKeyManager {
     }
     
     static func needToRegenerate() -> Bool {
-        guard KeyChain.wgPublicKey != nil else { return false }
         guard Date() > UserDefaults.shared.wgKeyTimestamp.addingTimeInterval(ExtensionKeyManager.regenerationInterval) else { return false }
         
         return true


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Description

App should remove current WireGuard keys before calling rotate key API. If API call fails, app needs to generate new keys when user tries to connect to the VPN.

Resolves #133

