### PR TITLE
Missing expired subscription alert when 'active_until = 0'

### DIFF
--- a/IVPNClient/Models/ServiceStatus.swift
+++ b/IVPNClient/Models/ServiceStatus.swift
@@ -106,7 +106,7 @@ struct ServiceStatus: Codable {
     }
     
     func isActiveUntilValid() -> Bool {
-        return activeUntil != nil && (activeUntil ?? 0) > 0
+        return activeUntil != nil
     }
     
     func activeUntilExpired() -> Bool {

--- a/UnitTests/Models/ServiceStatusTests.swift
+++ b/UnitTests/Models/ServiceStatusTests.swift
@@ -85,7 +85,7 @@ class ServiceStatusTests: XCTestCase {
         model.activeUntil = nil
         XCTAssertFalse(model.isActiveUntilValid())
         model.activeUntil = 0
-        XCTAssertFalse(model.isActiveUntilValid())
+        XCTAssertTrue(model.isActiveUntilValid())
         model.activeUntil = 1578643221
         XCTAssertTrue(model.isActiveUntilValid())
     }


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Description

When logging in with an inactive account, the app does not show the alert "Your subscription has expired" + "RENEW" action button.

Apparently the app only shows the alert when the param 'active_until' uses a valid timestamp, however for new accounts the param 'active_until' is always 0.

Resolves #137
