### PR TITLE
Support force log in when 2FA or Captcha is required

### DIFF
--- a/IVPNClient.xcodeproj/project.pbxproj
+++ b/IVPNClient.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		8270D266241A477900B17B65 /* InfoAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8270D265241A477900B17B65 /* InfoAlertView.swift */; };
 		8270D268241BB3D100B17B65 /* InfoAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8270D267241BB3D000B17B65 /* InfoAlertViewModel.swift */; };
 		82712DB922314AB100833445 /* TimerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82712DB822314AB100833445 /* TimerManager.swift */; };
+		827694F3263C04C40058B4DC /* LoginConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827694F2263C04C40058B4DC /* LoginConfirmation.swift */; };
 		82774855237596DF0061BD46 /* OpenVPNConf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82774854237596DF0061BD46 /* OpenVPNConf.swift */; };
 		8277F1CD22118D08007C6F15 /* ProofsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277F1CC22118D08007C6F15 /* ProofsViewModel.swift */; };
 		8277F1CF2211A602007C6F15 /* GeoLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8277F1CE2211A602007C6F15 /* GeoLookup.swift */; };
@@ -498,6 +499,7 @@
 		8270D265241A477900B17B65 /* InfoAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoAlertView.swift; sourceTree = "<group>"; };
 		8270D267241BB3D000B17B65 /* InfoAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoAlertViewModel.swift; sourceTree = "<group>"; };
 		82712DB822314AB100833445 /* TimerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerManager.swift; sourceTree = "<group>"; };
+		827694F2263C04C40058B4DC /* LoginConfirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginConfirmation.swift; sourceTree = "<group>"; };
 		82774854237596DF0061BD46 /* OpenVPNConf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenVPNConf.swift; sourceTree = "<group>"; };
 		8277F1CC22118D08007C6F15 /* ProofsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProofsViewModel.swift; sourceTree = "<group>"; };
 		8277F1CE2211A602007C6F15 /* GeoLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoLookup.swift; sourceTree = "<group>"; };
@@ -909,6 +911,7 @@
 				826C56D122FD4F2600D2B76A /* ServiceStatus.swift */,
 				82DAB37A2457013900302F4C /* Service.swift */,
 				8243587025DBB73E005FDEBB /* SecureDNS.swift */,
+				827694F2263C04C40058B4DC /* LoginConfirmation.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2128,6 +2131,7 @@
 				9C28337B1D9D3F060024C553 /* LoginViewController.swift in Sources */,
 				8205963D2245264300011091 /* UITableViewController+Ext.swift in Sources */,
 				82BF32F624484E5100248E4F /* CreateAccountView.swift in Sources */,
+				827694F3263C04C40058B4DC /* LoginConfirmation.swift in Sources */,
 				82774855237596DF0061BD46 /* OpenVPNConf.swift in Sources */,
 				82589A2B21FB5A580009CC6C /* UIImage+Ext.swift in Sources */,
 				829D2C8221664D5E004FA2B3 /* NSMutableAttributedString+Ext.swift in Sources */,

--- a/IVPNClient/Models/LoginConfirmation.swift
+++ b/IVPNClient/Models/LoginConfirmation.swift
@@ -1,0 +1,38 @@
+//
+//  LoginConfirmation.swift
+//  IVPN iOS app
+//  https://github.com/ivpn/ios-app
+//
+//  Created by Juraj Hilje on 2021-04-30.
+//  Copyright (c) 2021 Privatus Limited.
+//
+//  This file is part of the IVPN iOS app.
+//
+//  The IVPN iOS app is free software: you can redistribute it and/or
+//  modify it under the terms of the GNU General Public License as published by the Free
+//  Software Foundation, either version 3 of the License, or (at your option) any later version.
+//
+//  The IVPN iOS app is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+//  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+//  details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with the IVPN iOS app. If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+struct LoginConfirmation {
+    
+    var confirmation: String?
+    var captcha: String?
+    var captchaId: String?
+    
+    mutating func clear() {
+        confirmation = nil
+        captcha = nil
+        captchaId = nil
+    }
+    
+}

--- a/IVPNClient/Scenes/Signup/LoginViewController.swift
+++ b/IVPNClient/Scenes/Signup/LoginViewController.swift
@@ -295,6 +295,8 @@ extension LoginViewController {
         
         if let error = error as? ErrorResultSessionNew, let data = error.data {
             if data.upgradable {
+                NotificationCenter.default.removeObserver(self, name: Notification.Name.NewSession, object: nil)
+                NotificationCenter.default.removeObserver(self, name: Notification.Name.ForceNewSession, object: nil)
                 NotificationCenter.default.addObserver(self, selector: #selector(newSession), name: Notification.Name.NewSession, object: nil)
                 NotificationCenter.default.addObserver(self, selector: #selector(forceNewSession), name: Notification.Name.ForceNewSession, object: nil)
                 UserDefaults.shared.set(data.limit, forKey: UserDefaults.Key.sessionsLimit)

--- a/IVPNClient/Scenes/Signup/LoginViewController.swift
+++ b/IVPNClient/Scenes/Signup/LoginViewController.swift
@@ -132,10 +132,30 @@ class LoginViewController: UIViewController {
     }
     
     @objc func newSession() {
+        if let confirmation = loginConfirmation.confirmation {
+            startLoginProcess(confirmation: confirmation)
+            return
+        }
+        
+        if let captcha = loginConfirmation.captcha, let captchaId = loginConfirmation.captchaId {
+            startLoginProcess(captcha: captcha, captchaId: captchaId)
+            return
+        }
+        
         startLoginProcess()
     }
     
     @objc func forceNewSession() {
+        if let confirmation = loginConfirmation.confirmation {
+            startLoginProcess(force: true, confirmation: confirmation)
+            return
+        }
+        
+        if let captcha = loginConfirmation.captcha, let captchaId = loginConfirmation.captchaId {
+            startLoginProcess(force: true, captcha: captcha, captchaId: captchaId)
+            return
+        }
+        
         startLoginProcess(force: true)
     }
     
@@ -422,7 +442,7 @@ extension LoginViewController: TwoFactorViewControllerDelegate {
     
     func codeSubmitted(code: String) {
         loginConfirmation.confirmation = code
-        startLoginProcess(force: false, confirmation: code)
+        startLoginProcess(confirmation: code)
     }
     
 }
@@ -434,7 +454,7 @@ extension LoginViewController: CaptchaViewControllerDelegate {
     func captchaSubmitted(code: String, captchaId: String) {
         loginConfirmation.captcha = code
         loginConfirmation.captchaId = captchaId
-        startLoginProcess(force: false, captcha: code, captchaId: captchaId)
+        startLoginProcess(captcha: code, captchaId: captchaId)
     }
     
 }


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Description

With the current app implementation, there is a case when it is not possible to force login when reaching session limit with 2FA or captcha enabled.

Apps need to handle the case like this:
- 2FA or captcha code is sent to `/session/new` API
- If API returns "Too many sessions" response and user starts `/session/new` with `force: true`, app needs to also include 2FA or captcha code from the previous API call

Resolves #139
